### PR TITLE
Refactor chat UI with modern styling

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,5 @@
 import os
 import tkinter as tk
-from tkinter import scrolledtext
 
 try:
     from letta.schemas.memory import ChatMemory
@@ -14,14 +13,40 @@ class ChatApp:
         master.geometry("600x700")
         master.configure(bg="#f7f5f2")
 
-        self.chat_display = scrolledtext.ScrolledText(master, wrap=tk.WORD, state='disabled', bg='#ffffff', font=('Helvetica', 12))
-        self.chat_display.pack(padx=10, pady=10, fill=tk.BOTH, expand=True)
+        # sidebar for conversation titles
+        self.sidebar = tk.Frame(master, width=180, bg="#ececec")
+        self.sidebar.pack(side=tk.LEFT, fill=tk.Y)
+        tk.Label(self.sidebar, text="Conversations", bg="#ececec", font=("Helvetica", 14, "bold")).pack(pady=10)
 
-        self.entry = tk.Entry(master, width=80)
+        # main chat container
+        self.chat_container = tk.Frame(master, bg="#f7f5f2")
+        self.chat_container.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+
+        # scrolling area for messages
+        self.canvas = tk.Canvas(self.chat_container, bg="#f7f5f2", highlightthickness=0)
+        self.scrollbar = tk.Scrollbar(self.chat_container, orient="vertical", command=self.canvas.yview)
+        self.canvas.configure(yscrollcommand=self.scrollbar.set)
+        self.scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+        self.canvas.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        self.messages_frame = tk.Frame(self.canvas, bg="#f7f5f2")
+        self.canvas.create_window((0, 0), window=self.messages_frame, anchor="nw")
+        self.messages_frame.bind(
+            "<Configure>", lambda e: self.canvas.configure(scrollregion=self.canvas.bbox("all"))
+        )
+
+        # input area styled like modern chats
+        self.entry = tk.Entry(self.chat_container, font=("Helvetica", 12), bg="#ffffff", relief=tk.FLAT)
         self.entry.pack(padx=10, pady=(0, 10), side=tk.LEFT, expand=True, fill=tk.X)
         self.entry.bind("<Return>", self.send_message)
 
-        self.send_button = tk.Button(master, text="Send", command=self.send_message)
+        self.send_button = tk.Button(
+            self.chat_container,
+            text="Send",
+            command=self.send_message,
+            bg="#4a90e2",
+            fg="white",
+            relief=tk.FLAT,
+        )
         self.send_button.pack(padx=10, pady=(0, 10), side=tk.RIGHT)
 
         if ChatMemory:
@@ -30,10 +55,23 @@ class ChatApp:
             self.memory = None
 
     def append_to_chat(self, speaker, text):
-        self.chat_display['state'] = 'normal'
-        self.chat_display.insert(tk.END, f"{speaker}: {text}\n")
-        self.chat_display['state'] = 'disabled'
-        self.chat_display.see(tk.END)
+        frame = tk.Frame(self.messages_frame, bg="#f7f5f2")
+        bg = "#e1ffc7" if speaker == "You" else "#ffffff"
+        anchor = "e" if speaker == "You" else "w"
+        label = tk.Label(
+            frame,
+            text=text,
+            bg=bg,
+            wraplength=400,
+            justify=tk.LEFT,
+            font=("Helvetica", 12),
+            padx=10,
+            pady=5,
+        )
+        label.pack(anchor=anchor, pady=2, padx=10)
+        frame.pack(fill=tk.BOTH, anchor=anchor)
+        self.canvas.update_idletasks()
+        self.canvas.yview_moveto(1.0)
 
     def send_message(self, event=None):
         user_input = self.entry.get().strip()


### PR DESCRIPTION
## Summary
- refactor chat layout to use frames and canvas scrolling
- add sidebar for conversation list
- show messages as individual labels with alternating alignment
- improve fonts and input area styling for a modern look

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686282a38ccc83269d52d08959c4e592